### PR TITLE
Update getting-started.mdx

### DIFF
--- a/src/content/docs/en/installation/getting-started.mdx
+++ b/src/content/docs/en/installation/getting-started.mdx
@@ -34,7 +34,7 @@ Ultramarine Linux comes in 4 variants:
 - **Flagship Edition**: Our default and most popular variant. Choose Flagship if you'd like a familiar and stylish experience.
 - **GNOME Edition**: Elegant and Modern. Choose GNOME if you'd like a simple, unique experience.
 - **Pantheon Edition**: Our second most popular variant. Choose Pantheon if you'd like a thoughtful and capable experience.
-- **KDE Edition**: Our newest variant. Choose KDE id you'd like a simply customisable experience.
+- **KDE Edition**: Our newest variant. Choose KDE if you'd like a simply customisable experience.
 
 Ultramarine Linux supports 64bit Intel, AMD, and ARM computers.
 


### PR DESCRIPTION
typo fix - 
line 37: changes "id" to "if" (the kde edition line under "choosing your edition")