### PR TITLE
Fix Edit This Page Button

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -17,7 +17,7 @@ type Props = CollectionEntry<"docs">["data"] & {
 const { headings, ...data } = Astro.props;
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const currentPage = Astro.url.pathname;
-const currentFile = `src/content/docs${currentPage.replace(/\/$/, "")}.md`;
+const currentFile = `src/content/docs${currentPage.replace(/\/$/, "")}.mdx`;
 const githubEditUrl = `${GITHUB_EDIT_URL}/${currentFile}`;
 ---
 


### PR DESCRIPTION
The **Edit this page** button on the websites point to the wrong URL. The file extensions where at some point changed from `md` to `mdx`, and this was not properly updated. The button leads to a 404.