### PR TITLE
fix: change on Footer.astro file to automatically include the current year

### DIFF
--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -3,7 +3,7 @@ import ThemeToggleButton from "../RightSidebar/ThemeToggleButton";
 ---
 
 <footer>
-  <p>Copyright © 2021 - 2024 Fyra Labs</p>
+  <p>Copyright © 2021 - {new Date().getFullYear()} Fyra Labs</p>
   <ThemeToggleButton client:visible />
 </footer>
 


### PR DESCRIPTION
Quick fix to eliminate the hassle of manually changing the year in the page footer.